### PR TITLE
Implement sign-out functionality for Cashier and Operations sidebars Maintaining the same design given

### DIFF
--- a/frontEnd/src/components/CashierSideBar.js
+++ b/frontEnd/src/components/CashierSideBar.js
@@ -1,7 +1,16 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom"; // Import `useNavigate` for navigation
 import "./Sidebar.css";
 
 const CashierSideBar = () => {
+  const navigate = useNavigate(); // Hook for programmatic navigation
+
+  // Function to handle sign out
+  const handleSignOut = (e) => {
+    e.preventDefault(); // Prevent default anchor behavior
+    localStorage.removeItem("authToken"); // Clear the auth token
+    navigate("/"); // Redirect to the login page
+  };
+
   return (
     <div className="sidebar">
       <div className="sidebar-logo">
@@ -16,7 +25,7 @@ const CashierSideBar = () => {
             {/* Transaction Menu */}
             <li>
               <a
-                className="nav-link  transaction-nav"
+                className="nav-link transaction-nav"
                 href="#transaction"
                 role="button"
                 data-bs-toggle="collapse"
@@ -64,14 +73,14 @@ const CashierSideBar = () => {
           </div>
         </div>
         <div className="sidebar-signout">
-          <Link to="/">
-            <a href="#signout" className="signout-link">
-              Sign out <i className="fas fa-sign-out-alt"></i>
-            </a>
-          </Link>
+          {/* Using an <a> tag with onClick handler */}
+          <a href="/" onClick={handleSignOut} className="signout-link">
+            Sign out <i className="fas fa-sign-out-alt"></i>
+          </a>
         </div>
       </div>
     </div>
   );
 };
+
 export default CashierSideBar;

--- a/frontEnd/src/components/Sidebar.js
+++ b/frontEnd/src/components/Sidebar.js
@@ -6,8 +6,8 @@ export default function Sidebar() {
   const navigate = useNavigate(); // Added: Hook for redirecting users to the login page after logout.
 
   // Logout Functionality
-  const handleLogout = () => {
-    // Clear localStorage
+  const handleLogout = (e) => {
+    e.preventDefault(); // Prevent default anchor behavior to handle it programmatically
     localStorage.removeItem("authToken"); // Added: Removes the user's authentication token from localStorage.
     localStorage.removeItem("userRole"); // Added: Removes the user's role from localStorage.
 
@@ -82,10 +82,10 @@ export default function Sidebar() {
           </div>
         </div>
         <div className="sidebar-signout">
-          {/* Changed from <a> to <button> for accessibility and to attach logout logic */}
-          <button onClick={handleLogout} className="signout-link">
+          {/* Using an <a> tag with onClick handler for logout functionality */}
+          <a href="/" onClick={handleLogout} className="signout-link">
             Sign out <i className="fas fa-sign-out-alt"></i>
-          </button>
+          </a>
         </div>
       </div>
     </div>

--- a/server/controllers/paymentController.js
+++ b/server/controllers/paymentController.js
@@ -57,9 +57,6 @@ exports.createPayment = (req, res) => {
 };
 
 
-
-
-
 // Get all payments (Cashier Only)
 exports.getAllPayments = (req, res) => {
   db.query('SELECT * FROM payments', (err, results) => {


### PR DESCRIPTION
Summary
This pull request introduces a consistent sign-out functionality to both the Cashier and Operations sidebars. Users can now securely log out, clearing their session data and being redirected to the login page.

### Changes Implemented
- **Cashier Sidebar:**
  - Added a sign-out link (`<a>`) that triggers the `handleSignOut` function.
  - The function clears the `authToken` from `localStorage` and navigates the user to the login page.
  - Ensured aesthetic consistency by using the `<a>` tag for the sign-out link, while handling the logout process programmatically.

- **Operations Sidebar:**
  - Implemented a similar sign-out mechanism as the Cashier sidebar for uniform user experience.
  - Utilized the `useNavigate` hook from `react-router-dom` for smooth navigation after logout.

### Testing
- Verified that clicking the sign-out link successfully clears the session and redirects to the login page.
- Tested the functionality across both Cashier and Operations views to ensure consistency.